### PR TITLE
Refactor: Split Contract into Modular Structure

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -9,6 +9,9 @@ use serde_json;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, DocumentResponse, CollectionResponse, WriteOperation, WriteType};
 use crate::state::{Document, CollectionPermissions, PermissionLevel, DOCUMENTS, ADMIN, COLLECTION_PERMISSIONS, USER_ROLES};
 
+pub mod execute;
+pub mod query;
+
 const CONTRACT_NAME: &str = "firebase-storage";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -36,32 +39,12 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> StdResult<Response> {
-    match msg {
-        ExecuteMsg::Set { collection, document, data } => {
-            execute_set(deps, env, info, collection, document, data)
-        }
-        ExecuteMsg::Update { collection, document, data } => {
-            execute_update(deps, env, info, collection, document, data)
-        }
-        ExecuteMsg::Delete { collection, document } => {
-            execute_delete(deps, env, info, collection, document)
-        }
-        ExecuteMsg::BatchWrite { operations } => {
-            execute_batch_write(deps, env, info, operations)
-        }
-        ExecuteMsg::SetCollectionPermissions { collection, permissions } => {
-            execute_set_permissions(deps, env, info, collection, permissions)
-        }
-        ExecuteMsg::GrantRole { user, role } => {
-            execute_grant_role(deps, env, info, user, role)
-        }
-        ExecuteMsg::RevokeRole { user, role } => {
-            execute_revoke_role(deps, env, info, user, role)
-        }
-        ExecuteMsg::TransferAdmin { new_admin } => {
-            execute_transfer_admin(deps, env, info, new_admin)
-        }
-    }
+    execute::execute(deps, env, info, msg)
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    query::query(deps, msg)
 }
 
 fn execute_set(
@@ -286,30 +269,6 @@ fn execute_transfer_admin(
         .add_attribute("action", "transfer_admin")
         .add_attribute("old_admin", admin)
         .add_attribute("new_admin", new_admin_addr))
-}
-
-#[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
-    match msg {
-        QueryMsg::Get { collection, document } => {
-            query_get(deps, collection, document)
-        }
-        QueryMsg::Collection { collection, limit, start_after } => {
-            query_collection(deps, collection, limit, start_after)
-        }
-        QueryMsg::UserDocuments { owner, collection, limit, start_after } => {
-            query_user_documents(deps, owner, collection, limit, start_after)
-        }
-        QueryMsg::GetCollectionPermissions { collection } => {
-            query_collection_permissions(deps, collection)
-        }
-        QueryMsg::GetUserRoles { user } => {
-            query_user_roles(deps, user)
-        }
-        QueryMsg::CheckPermission { collection, user, action } => {
-            query_check_permission(deps, collection, user, action)
-        }
-    }
 }
 
 fn query_get(

--- a/src/execute/batch.rs
+++ b/src/execute/batch.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{
+    DepsMut, Env, MessageInfo, Response, StdResult,
+};
+
+use crate::msg::WriteOperation;
+use crate::execute::{set, update, delete};
+
+pub fn execute_batch_write(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    operations: Vec<WriteOperation>,
+) -> StdResult<Response> {
+    for op in operations {
+        match op.operation {
+            WriteType::Set { data } => {
+                set::execute_set(deps.branch(), env.clone(), info.clone(), op.collection, op.document, data)?;
+            }
+            WriteType::Update { data } => {
+                update::execute_update(deps.branch(), env.clone(), info.clone(), op.collection, op.document, data)?;
+            }
+            WriteType::Delete => {
+                delete::execute_delete(deps.branch(), env.clone(), info.clone(), op.collection, op.document)?;
+            }
+        }
+    }
+    
+    Ok(Response::new().add_attribute("action", "batch_write"))
+} 

--- a/src/execute/delete.rs
+++ b/src/execute/delete.rs
@@ -1,0 +1,36 @@
+use cosmwasm_std::{
+    Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+
+use crate::state::{DOCUMENTS, ADMIN};
+use crate::query::check_permission;
+
+pub fn execute_delete(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    collection: String,
+    document_id: String,
+) -> StdResult<Response> {
+    let key = (collection.clone(), document_id.clone());
+    
+    // Check if document exists
+    let doc = DOCUMENTS.load(deps.storage, key.clone())?;
+    
+    // Check if user owns document OR has delete permission for collection
+    let admin = ADMIN.load(deps.storage)?;
+    let owns_document = doc.owner == info.sender;
+    let is_admin = info.sender == admin;
+    let has_delete_permission = check_permission(deps.as_ref(), &collection, &info.sender, "delete")?;
+    
+    if !owns_document && !is_admin && !has_delete_permission {
+        return Err(StdError::generic_err("Unauthorized: Must own document or have delete permission"));
+    }
+    
+    DOCUMENTS.remove(deps.storage, key);
+    
+    Ok(Response::new()
+        .add_attribute("action", "delete")
+        .add_attribute("collection", collection)
+        .add_attribute("document", document_id))
+} 

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -1,0 +1,47 @@
+use cosmwasm_std::{
+    Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+use serde_json;
+
+use crate::msg::{ExecuteMsg, WriteOperation, WriteType};
+use crate::state::{Document, CollectionPermissions, DOCUMENTS, ADMIN, COLLECTION_PERMISSIONS, USER_ROLES};
+
+pub mod set;
+pub mod update;
+pub mod delete;
+pub mod batch;
+pub mod permissions;
+
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Set { collection, document, data } => {
+            set::execute_set(deps, env, info, collection, document, data)
+        }
+        ExecuteMsg::Update { collection, document, data } => {
+            update::execute_update(deps, env, info, collection, document, data)
+        }
+        ExecuteMsg::Delete { collection, document } => {
+            delete::execute_delete(deps, env, info, collection, document)
+        }
+        ExecuteMsg::BatchWrite { operations } => {
+            batch::execute_batch_write(deps, env, info, operations)
+        }
+        ExecuteMsg::SetCollectionPermissions { collection, permissions } => {
+            permissions::execute_set_permissions(deps, env, info, collection, permissions)
+        }
+        ExecuteMsg::GrantRole { user, role } => {
+            permissions::execute_grant_role(deps, env, info, user, role)
+        }
+        ExecuteMsg::RevokeRole { user, role } => {
+            permissions::execute_revoke_role(deps, env, info, user, role)
+        }
+        ExecuteMsg::TransferAdmin { new_admin } => {
+            permissions::execute_transfer_admin(deps, env, info, new_admin)
+        }
+    }
+} 

--- a/src/execute/permissions.rs
+++ b/src/execute/permissions.rs
@@ -1,0 +1,98 @@
+use cosmwasm_std::{
+    Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+
+use crate::state::{CollectionPermissions, ADMIN, COLLECTION_PERMISSIONS, USER_ROLES};
+
+pub fn execute_set_permissions(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    collection: String,
+    permissions: CollectionPermissions,
+) -> StdResult<Response> {
+    // Only admin can set permissions
+    let admin = ADMIN.load(deps.storage)?;
+    if info.sender != admin {
+        return Err(StdError::generic_err("Only admin can set collection permissions"));
+    }
+    
+    COLLECTION_PERMISSIONS.save(deps.storage, collection.clone(), &permissions)?;
+    
+    Ok(Response::new()
+        .add_attribute("action", "set_permissions")
+        .add_attribute("collection", collection))
+}
+
+pub fn execute_grant_role(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    user: String,
+    role: String,
+) -> StdResult<Response> {
+    // Only admin can grant roles
+    let admin = ADMIN.load(deps.storage)?;
+    if info.sender != admin {
+        return Err(StdError::generic_err("Only admin can grant roles"));
+    }
+    
+    let user_addr = deps.api.addr_validate(&user)?;
+    let mut user_roles = USER_ROLES.may_load(deps.storage, user_addr.clone())?.unwrap_or_default();
+    
+    if !user_roles.contains(&role) {
+        user_roles.push(role.clone());
+        USER_ROLES.save(deps.storage, user_addr, &user_roles)?;
+    }
+    
+    Ok(Response::new()
+        .add_attribute("action", "grant_role")
+        .add_attribute("user", user)
+        .add_attribute("role", role))
+}
+
+pub fn execute_revoke_role(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    user: String,
+    role: String,
+) -> StdResult<Response> {
+    // Only admin can revoke roles
+    let admin = ADMIN.load(deps.storage)?;
+    if info.sender != admin {
+        return Err(StdError::generic_err("Only admin can revoke roles"));
+    }
+    
+    let user_addr = deps.api.addr_validate(&user)?;
+    let mut user_roles = USER_ROLES.may_load(deps.storage, user_addr.clone())?.unwrap_or_default();
+    
+    user_roles.retain(|r| r != &role);
+    USER_ROLES.save(deps.storage, user_addr, &user_roles)?;
+    
+    Ok(Response::new()
+        .add_attribute("action", "revoke_role")
+        .add_attribute("user", user)
+        .add_attribute("role", role))
+}
+
+pub fn execute_transfer_admin(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    new_admin: String,
+) -> StdResult<Response> {
+    // Only current admin can transfer admin
+    let admin = ADMIN.load(deps.storage)?;
+    if info.sender != admin {
+        return Err(StdError::generic_err("Only admin can transfer admin role"));
+    }
+    
+    let new_admin_addr = deps.api.addr_validate(&new_admin)?;
+    ADMIN.save(deps.storage, &new_admin_addr)?;
+    
+    Ok(Response::new()
+        .add_attribute("action", "transfer_admin")
+        .add_attribute("old_admin", admin)
+        .add_attribute("new_admin", new_admin_addr))
+} 

--- a/src/execute/set.rs
+++ b/src/execute/set.rs
@@ -1,0 +1,41 @@
+use cosmwasm_std::{
+    Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+use serde_json;
+
+use crate::state::{Document, DOCUMENTS};
+use crate::query::check_permission;
+
+pub fn execute_set(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    collection: String,
+    document_id: String,
+    data: String,
+) -> StdResult<Response> {
+    // Check create permission
+    if !check_permission(deps.as_ref(), &collection, &info.sender, "create")? {
+        return Err(StdError::generic_err("Insufficient permissions to create documents in this collection"));
+    }
+    
+    // Validate JSON
+    serde_json::from_str::<serde_json::Value>(&data)
+        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    
+    let doc = Document {
+        data,
+        owner: info.sender.clone(),
+        created_at: env.block.time,
+        updated_at: env.block.time,
+    };
+    
+    let key = (collection.clone(), document_id.clone());
+    DOCUMENTS.save(deps.storage, key, &doc)?;
+    
+    Ok(Response::new()
+        .add_attribute("action", "set")
+        .add_attribute("collection", collection)
+        .add_attribute("document", document_id)
+        .add_attribute("owner", info.sender))
+} 

--- a/src/execute/update.rs
+++ b/src/execute/update.rs
@@ -1,0 +1,60 @@
+use cosmwasm_std::{
+    Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+use serde_json;
+
+use crate::state::{Document, DOCUMENTS, ADMIN};
+use crate::query::check_permission;
+
+pub fn execute_update(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    collection: String,
+    document_id: String,
+    data: String,
+) -> StdResult<Response> {
+    let key = (collection.clone(), document_id.clone());
+    
+    // Load existing document
+    let mut doc = DOCUMENTS.load(deps.storage, key.clone())?;
+    
+    // Check if user owns document OR has update permission for collection
+    let admin = ADMIN.load(deps.storage)?;
+    let owns_document = doc.owner == info.sender;
+    let is_admin = info.sender == admin;
+    let has_update_permission = check_permission(deps.as_ref(), &collection, &info.sender, "update")?;
+    
+    if !owns_document && !is_admin && !has_update_permission {
+        return Err(StdError::generic_err("Unauthorized: Must own document or have update permission"));
+    }
+    
+    // Merge JSON data
+    let existing: serde_json::Value = serde_json::from_str(&doc.data)
+        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    let new_data: serde_json::Value = serde_json::from_str(&data)
+        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    
+    let merged = merge_json(existing, new_data);
+    
+    doc.data = serde_json::to_string(&merged)
+        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    doc.updated_at = env.block.time;
+    
+    DOCUMENTS.save(deps.storage, key, &doc)?;
+    
+    Ok(Response::new()
+        .add_attribute("action", "update")
+        .add_attribute("collection", collection)
+        .add_attribute("document", document_id))
+}
+
+// Helper function to merge JSON objects
+fn merge_json(mut existing: serde_json::Value, new: serde_json::Value) -> serde_json::Value {
+    if let (serde_json::Value::Object(ref mut existing_map), serde_json::Value::Object(new_map)) = (&mut existing, &new) {
+        for (key, value) in new_map {
+            existing_map.insert(key.clone(), value.clone());
+        }
+    }
+    existing
+} 

--- a/src/query/collection.rs
+++ b/src/query/collection.rs
@@ -1,0 +1,92 @@
+use cosmwasm_std::{
+    to_json_binary, Addr, Binary, Deps, StdResult, Order,
+};
+use cw_storage_plus::Bound;
+
+use crate::msg::CollectionResponse;
+use crate::state::{Document, DOCUMENTS};
+
+pub fn query_collection(
+    deps: Deps,
+    collection: String,
+    limit: Option<u32>,
+    start_after: Option<String>,
+) -> StdResult<Binary> {
+    let limit = limit.unwrap_or(30) as usize;
+    
+    let start = start_after.as_ref().map(|s| Bound::exclusive((collection.clone(), s.clone())));
+    let end = Bound::exclusive((format!("{}~", collection), String::new()));
+    
+    let documents: Vec<(String, Document)> = DOCUMENTS
+        .range(deps.storage, start, Some(end), Order::Ascending)
+        .take(limit)
+        .map(|item| {
+            let ((_, doc_id), doc) = item?;
+            Ok((doc_id, doc))
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+    
+    let next_start_after = if documents.len() == limit {
+        documents.last().map(|(id, _)| id.clone())
+    } else {
+        None
+    };
+    
+    let response = CollectionResponse {
+        documents,
+        next_start_after,
+    };
+    
+    to_json_binary(&response)
+}
+
+pub fn query_user_documents(
+    deps: Deps,
+    owner: String,
+    collection: Option<String>,
+    limit: Option<u32>,
+    start_after: Option<String>,
+) -> StdResult<Binary> {
+    let owner_addr = deps.api.addr_validate(&owner)?;
+    let limit = limit.unwrap_or(30) as usize;
+    
+    let start = if let (Some(coll), Some(s)) = (collection.clone(), start_after.clone()) {
+        Some(Bound::exclusive((coll, s)))
+    } else {
+        None
+    };
+    
+    let documents: Vec<(String, Document)> = DOCUMENTS
+        .idx
+        .owner
+        .prefix(owner_addr)
+        .range(deps.storage, start, None, Order::Ascending)
+        .filter_map(|item| {
+            let (key, doc) = item.ok()?;
+            let (coll, doc_id) = key;
+            
+            // Filter by collection if specified
+            if let Some(ref filter_collection) = collection {
+                if &coll != filter_collection {
+                    return None;
+                }
+            }
+            
+            Some((doc_id, doc))
+        })
+        .take(limit)
+        .collect();
+    
+    let next_start_after = if documents.len() == limit {
+        documents.last().map(|(id, _)| id.clone())
+    } else {
+        None
+    };
+    
+    let response = CollectionResponse {
+        documents,
+        next_start_after,
+    };
+    
+    to_json_binary(&response)
+} 

--- a/src/query/get.rs
+++ b/src/query/get.rs
@@ -1,0 +1,22 @@
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, StdResult,
+};
+
+use crate::msg::DocumentResponse;
+use crate::state::DOCUMENTS;
+
+pub fn query_get(
+    deps: Deps,
+    collection: String,
+    document_id: String,
+) -> StdResult<Binary> {
+    let key = (collection, document_id);
+    let doc = DOCUMENTS.may_load(deps.storage, key)?;
+    
+    let response = DocumentResponse {
+        exists: doc.is_some(),
+        document: doc,
+    };
+    
+    to_json_binary(&response)
+} 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,71 @@
+use cosmwasm_std::{
+    to_json_binary, Addr, Binary, Deps, StdResult,
+};
+
+use crate::msg::{QueryMsg, DocumentResponse, CollectionResponse};
+use crate::state::{DOCUMENTS, ADMIN, COLLECTION_PERMISSIONS, USER_ROLES};
+
+pub mod get;
+pub mod collection;
+pub mod permissions;
+
+pub fn query(deps: Deps, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Get { collection, document } => {
+            get::query_get(deps, collection, document)
+        }
+        QueryMsg::Collection { collection, limit, start_after } => {
+            collection::query_collection(deps, collection, limit, start_after)
+        }
+        QueryMsg::UserDocuments { owner, collection, limit, start_after } => {
+            collection::query_user_documents(deps, owner, collection, limit, start_after)
+        }
+        QueryMsg::GetCollectionPermissions { collection } => {
+            permissions::query_collection_permissions(deps, collection)
+        }
+        QueryMsg::GetUserRoles { user } => {
+            permissions::query_user_roles(deps, user)
+        }
+        QueryMsg::CheckPermission { collection, user, action } => {
+            permissions::query_check_permission(deps, collection, user, action)
+        }
+    }
+}
+
+// Permission checking helper function
+pub fn check_permission(
+    deps: Deps,
+    collection: &str,
+    user: &Addr,
+    action: &str,
+) -> StdResult<bool> {
+    // Admin always has permission
+    let admin = ADMIN.load(deps.storage)?;
+    if user == &admin {
+        return Ok(true);
+    }
+    
+    // Get collection permissions (use defaults if not set)
+    let permissions = COLLECTION_PERMISSIONS.may_load(deps.storage, collection.to_string())?
+        .unwrap_or_default();
+    
+    let permission_level = match action {
+        "create" => &permissions.create,
+        "update" => &permissions.update,
+        "delete" => &permissions.delete,
+        "read" => &permissions.read,
+        _ => return Ok(false), // Unknown action
+    };
+    
+    match permission_level {
+        PermissionLevel::Anyone => Ok(true),
+        PermissionLevel::AdminOnly => Ok(user == &admin),
+        PermissionLevel::AllowList(allowed_users) => Ok(allowed_users.contains(&user.to_string())),
+        PermissionLevel::DenyList(denied_users) => Ok(!denied_users.contains(&user.to_string())),
+        PermissionLevel::RequireRole(required_role) => {
+            let user_roles = USER_ROLES.may_load(deps.storage, user.clone())?
+                .unwrap_or_default();
+            Ok(user_roles.contains(required_role))
+        }
+    }
+} 

--- a/src/query/permissions.rs
+++ b/src/query/permissions.rs
@@ -1,0 +1,35 @@
+use cosmwasm_std::{
+    to_json_binary, Addr, Binary, Deps, StdResult,
+};
+
+use crate::state::{COLLECTION_PERMISSIONS, USER_ROLES};
+
+pub fn query_collection_permissions(
+    deps: Deps,
+    collection: String,
+) -> StdResult<Binary> {
+    let permissions = COLLECTION_PERMISSIONS.may_load(deps.storage, collection)?
+        .unwrap_or_default();
+    to_json_binary(&permissions)
+}
+
+pub fn query_user_roles(
+    deps: Deps,
+    user: String,
+) -> StdResult<Binary> {
+    let user_addr = deps.api.addr_validate(&user)?;
+    let roles = USER_ROLES.may_load(deps.storage, user_addr)?
+        .unwrap_or_default();
+    to_json_binary(&roles)
+}
+
+pub fn query_check_permission(
+    deps: Deps,
+    collection: String,
+    user: String,
+    action: String,
+) -> StdResult<Binary> {
+    let user_addr = deps.api.addr_validate(&user)?;
+    let has_permission = super::check_permission(deps, &collection, &user_addr, &action)?;
+    to_json_binary(&has_permission)
+} 


### PR DESCRIPTION
This PR refactors the contract code into a more modular structure by splitting the large `contract.rs` file into separate modules for better organization and maintainability.

## Changes
- Created new module structure:
  - `src/execute/` - Contains all execute-related functionality
    - `mod.rs` - Main execute module with message routing
    - `set.rs` - Document creation logic
    - `update.rs` - Document update logic
    - `delete.rs` - Document deletion logic
    - `batch.rs` - Batch operation handling
    - `permissions.rs` - Permission management functions
  - `src/query/` - Contains all query-related functionality
    - `mod.rs` - Main query module with message routing
    - `get.rs` - Single document retrieval
    - `collection.rs` - Collection and user document queries
    - `permissions.rs` - Permission-related queries

## Benefits
- Improved code organization and maintainability
- Better separation of concerns
- Easier to locate and modify specific functionality
- Reduced file size and complexity
- More modular testing capabilities

## Testing
- All existing functionality remains unchanged
- No changes to the contract's external interface
- All tests should continue to pass

## Related Issues
[Add any related issue numbers here]

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] All tests pass
- [ ] Documentation has been updated if necessary
- [ ] No breaking changes to the contract's interface